### PR TITLE
Unpin sphinx version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==3.0.2
+sphinx
 nbsphinx
 ipykernel
 


### PR DESCRIPTION
the docs don't build on sphinx==3.0.2. People report having solved an issue with the same error message by using an up-to-date version of sphinx. => released the pinning of sphinx version.