### PR TITLE
Make pandas DataFrame default representation of tables

### DIFF
--- a/bioverse/classes.py
+++ b/bioverse/classes.py
@@ -69,8 +69,7 @@ class Table(dict):
         self.error = None
     
     def __repr__(self):
-        s1 = 'Table of {:d} objects with {:d} parameters'.format(len(self),len(self.keys()))
-        return s1
+        return self.pdshow()
 
     def __len__(self):
         """ Returns the number of rows in the table rather than the number of keys (default dict behavior). """
@@ -316,8 +315,9 @@ class Table(dict):
         if DataFrame is None:
             raise ModuleNotFoundError("Package `pandas` is required to display the Table")
         else:
-            print(self.__repr__())
-            print(DataFrame(self).__repr__())
+            df_rep = DataFrame(self).__repr__()
+            print(df_rep)
+            return df_rep
     
     def observed(self, key):
         """ Returns the subset of rows for which self[key] is not nan. """

--- a/bioverse/classes.py
+++ b/bioverse/classes.py
@@ -69,7 +69,11 @@ class Table(dict):
         self.error = None
     
     def __repr__(self):
-        return self.pdshow()
+        try:
+            return self.pdshow()
+        except ModuleNotFoundError:
+            s1 = 'Table of {:d} objects with {:d} parameters'.format(len(self), len(self.keys()))
+            return s1
 
     def __len__(self):
         """ Returns the number of rows in the table rather than the number of keys (default dict behavior). """
@@ -315,9 +319,9 @@ class Table(dict):
         if DataFrame is None:
             raise ModuleNotFoundError("Package `pandas` is required to display the Table")
         else:
-            df_rep = DataFrame(self).__repr__()
-            print(df_rep)
-            return df_rep
+            df_rep = DataFrame(self)
+            display(df_rep)
+            return ''
 
     def to_pandas(self):
         """export Table into a pandas DataFrame"""

--- a/bioverse/classes.py
+++ b/bioverse/classes.py
@@ -318,6 +318,11 @@ class Table(dict):
             df_rep = DataFrame(self).__repr__()
             print(df_rep)
             return df_rep
+
+    def to_pandas(self):
+        """export Table into a pandas DataFrame"""
+        df = DataFrame(self)
+        return df
     
     def observed(self, key):
         """ Returns the subset of rows for which self[key] is not nan. """

--- a/docs/table.rst
+++ b/docs/table.rst
@@ -15,12 +15,14 @@ Bioverse uses the :class:`~bioverse.classes.Table` class to manage large simulat
     # Returns all parameters for the first 50 planets
     table[:50]
 
-A Table is somewhat similar to a Pandas DataFrame; indeed, if Pandas is installed, then the Table can be displayed as one using the :meth:`~bioverse.classes.Table.pdshow` method:
+A Table is somewhat similar to a Pandas DataFrame.
+Indeed, if Pandas is installed, the Table will be displayed as one.
+To export a Table as a Pandas DataFrame, we can use the :meth:`~bioverse.classes.Table.to_pandas` method:
 
 .. code-block:: python
 
-    table.pdshow()
-    Table of 522 objects with 22 parameters
+    table.to_pandas()
+
               d      M_st      R_st      L_st   T_eff_st SpT  ...  N_pl  order         R            P         a           S
     0    13.779  0.891276  0.912031  0.668409  5469.6313   G  ...     1      0  2.279597   680.071360  1.456531    0.315067
     1    17.990  1.368140  1.285004  2.995380  6704.4496   F  ...     1      0  1.603131  4461.320947  5.887965    0.086402


### PR DESCRIPTION
pandas DataFrames are nicely rendered in Jupyter notebooks and add to the readibility of the data sets. 

This PR makes the previously implemented `pdshow()` call the default way of displaying a table. If pandas is not installed, the traditional display mode is used.