### PR TITLE
Fixes deprecated numpy.float; adds numpy.double.

### DIFF
--- a/bioverse/constants.py
+++ b/bioverse/constants.py
@@ -20,7 +20,7 @@ CATALOG_FILE = DATA_DIR+'Gaia.csv'
 FUNCTIONS_DIR = ROOT_DIR+'/functions/'
 
 # Program version
-VERSION = "1.0"
+VERSION = "1.1.1"
 
 # Physical constants (in cgs where applicable)
 CONST = {}

--- a/bioverse/constants.py
+++ b/bioverse/constants.py
@@ -39,7 +39,7 @@ CONST['S_Earth'] = 238.         # global-averaged, top-of-atmosphere insolation 
 # Data types
 ARRAY_TYPES = (np.ndarray,list,tuple)
 LIST_TYPES = ARRAY_TYPES
-FLOAT_TYPES = (float,np.float,np.float_,np.float64)
+FLOAT_TYPES = (float,np.double,np.float_,np.float64)
 INT_TYPES = (int,np.int_,np.int64,np.integer,np.int8)
 STR_TYPES = (str,np.str_)
 BOOL_TYPES = (bool,np.bool_)

--- a/bioverse/functions.py
+++ b/bioverse/functions.py
@@ -97,13 +97,13 @@ def read_stars_Gaia(d, filename='gcns_catalog.dat', d_max=120., M_st_min=0.075, 
 
     # Read the catalog with column names
     path = filename if os.path.exists(filename) else DATA_DIR + '/' + filename
-    cat = pd.read_csv(path,sep=' ',header=0,dtype={'star_name':str, 'd':np.float,
-                                                     'ra':np.float, 'dec':np.float,
-                                                     'M_G':np.float, 'M_st':np.float,
-                                                     'R_st':np.float, 'L_st':np.float,
-                                                     'T_eff_st':np.int, 'SpT':str,
+    cat = pd.read_csv(path,sep=' ',header=0,dtype={'star_name':str, 'd':float,
+                                                     'ra':float, 'dec':float,
+                                                     'M_G':float, 'M_st':float,
+                                                     'R_st':float, 'L_st':float,
+                                                     'T_eff_st':int, 'SpT':str,
                                                      'subSpT':str, 'binary':bool,
-                                                     'RV':np.float})
+                                                     'RV':float})
     catalog = cat.to_records(index=False)
     # catalog = np.genfromtxt(path, unpack=False, names=True, dtype=None, encoding=None)
     for name in catalog.dtype.names:
@@ -1222,7 +1222,7 @@ def magma_ocean(d, wrr=0.005, S_thresh=280., simplified=False, diff_frac=0.54, f
             purerock = pd.read_csv(DATA_DIR + 'mass-radius_relationships_mgsio3_Zeng2016.txt')
             purerock.loc[:, 'wrr'] = 0.
             turbet2020 = pd.read_csv(DATA_DIR + 'mass-radius_relationships_STEAM_TURBET2020_FIG2b.dat', comment='#')
-            mass_radius = purerock.append(turbet2020, ignore_index=True)
+            mass_radius = pd.concat([purerock, turbet2020], ignore_index=True)
 
             mass_radius = mass_radius[mass_radius.wrr == wrr]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ scipy
 tqdm
 pandas
 PyQt5
-astropy>=5.0.1
+astropy>=5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ scipy
 tqdm
 pandas
 PyQt5
+astropy>=5.0.1


### PR DESCRIPTION
This pull request fixes #23  by removing the deprecated `numpy.float` alias from `constants.py` Additionally, I have included a new alias `numpy.double` as a replacement, which represents the 64-bit floating-point data type and is equivalent to `numpy.float64`.

With these changes, the code will be updated to use[ the recommended aliases](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) for the appropriate data type, and the deprecated alias will be removed.
