### PR TITLE
restore compatibility with numpy >= 1.23

### DIFF
--- a/bioverse/constants.py
+++ b/bioverse/constants.py
@@ -39,7 +39,7 @@ CONST['S_Earth'] = 238.         # global-averaged, top-of-atmosphere insolation 
 # Data types
 ARRAY_TYPES = (np.ndarray,list,tuple)
 LIST_TYPES = ARRAY_TYPES
-FLOAT_TYPES = (float,np.float,np.float_,np.float64)
+FLOAT_TYPES = (float,np.float64,np.float_,np.float64)
 INT_TYPES = (int,np.int_,np.int64,np.integer,np.int8)
 STR_TYPES = (str,np.str_)
 BOOL_TYPES = (bool,np.bool_)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ scipy
 tqdm
 pandas
 PyQt5
+astropy>=5.0.1


### PR DESCRIPTION
This fixes #23 and additional incompatibilities with numpy versions >= 1.23 caused by older astropy versions.