### PR TITLE
Updated documentation to reflect pip install availability

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,23 +94,19 @@ Bioverse was developed with support from the following grants and collaborations
 Installation
 ************
 
-Bioverse can now be installed directly from PyPI. To install Bioverse, use the following command:
+The recommended way to install the latest stable version of Bioverse is via pip:
 
 .. code-block:: bash
 
     pip install bioverse
 
-Alternatively, Bioverse can be cloned from its GitHub repository:
+Alternatively, Bioverse can be cloned from its `GitHub repository <https://github.com/danielapai/bioverse/>`_:
 
 .. code-block:: bash
 
-    git clone https://github.com/danielapai/bioverse/
-
-To install Bioverse, navigate to the directory containing ``setup.py`` and run:
-
-.. code-block:: bash
-
-   pip install .
+    git clone https://www.github.com/danielapai/bioverse/
+    cd bioverse
+    pip install .
 
 Dependencies
 ************

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,13 @@ Bioverse was developed with support from the following grants and collaborations
 Installation
 ************
 
-Bioverse can be cloned from its GitHub repository:
+Bioverse can now be installed directly from PyPI. To install Bioverse, use the following command:
+
+.. code-block:: bash
+
+    pip install bioverse
+
+Alternatively, Bioverse can be cloned from its GitHub repository:
 
 .. code-block:: bash
 
@@ -105,8 +111,6 @@ To install Bioverse, navigate to the directory containing ``setup.py`` and run:
 .. code-block:: bash
 
    pip install .
-
-Bioverse will be added to PyPI in a future update.
 
 Dependencies
 ************

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,17 +13,20 @@ The :doc:`Overview<overview>` section describes the code's structure and primary
 Installation
 ************
 
-Bioverse can be cloned from its `GitHub repository <https://github.com/danielapai/bioverse/>`_:
+Bioverse can now be installed directly from PyPI. To install Bioverse, use the following command:
+
+.. code-block:: bash
+
+    pip install bioverse
+
+Alternatively, Bioverse can be cloned from its `GitHub repository <https://github.com/danielapai/bioverse/>`_:
 
 .. code-block:: bash
 
     git clone https://www.github.com/danielapai/bioverse/
+    cd bioverse
+    pip install .
 
-To install Bioverse, navigate to the directory containing ``setup.py`` and run: [#f1]_
-
-.. code-block:: bash
-
-   pip install .
 
 Dependencies
 ************

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ The :doc:`Overview<overview>` section describes the code's structure and primary
 Installation
 ************
 
-Bioverse can now be installed directly from PyPI. To install Bioverse, use the following command:
+The recommended way to install the latest stable version of Bioverse is via pip:
 
 .. code-block:: bash
 
@@ -82,9 +82,6 @@ Bioverse is compatible with Python 3.7+. It has the following dependencies, all 
    apidoc/bioverse.survey
    apidoc/bioverse.util
 
-.. rubric:: Footnotes
-
-.. [#f1] Bioverse will be added to PyPI in a future update.
 
 Feedback & Development
 **********************


### PR DESCRIPTION
New Installation Section:

Installation
************

Bioverse can now be installed directly from PyPI. To install Bioverse, use the following command:

.. code-block:: bash

    pip install bioverse

Alternatively, Bioverse can be cloned from its `GitHub repository <https://github.com/danielapai/bioverse/>`_:

.. code-block:: bash

    git clone https://www.github.com/danielapai/bioverse/
    cd bioverse
    pip install .