### PR TITLE
Add new installation to README.rst and index.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,13 @@ Bioverse was developed with support from the following grants and collaborations
 Installation
 ************
 
-Bioverse can be cloned from its GitHub repository:
+Bioverse can now be installed directly from PyPI. To install Bioverse, use the following command:
+
+.. code-block:: bash
+
+pip install bioverse
+
+Alternatively, Bioverse can be cloned from its GitHub repository:
 
 .. code-block:: bash
 
@@ -105,8 +111,6 @@ To install Bioverse, navigate to the directory containing ``setup.py`` and run:
 .. code-block:: bash
 
    pip install .
-
-Bioverse will be added to PyPI in a future update.
 
 Dependencies
 ************

--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ Bioverse can now be installed directly from PyPI. To install Bioverse, use the f
 
 .. code-block:: bash
 
-pip install bioverse
+    pip install bioverse
 
 Alternatively, Bioverse can be cloned from its GitHub repository:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,13 @@ The :doc:`Overview<overview>` section describes the code's structure and primary
 Installation
 ************
 
-Bioverse can be cloned from its `GitHub repository <https://github.com/danielapai/bioverse/>`_:
+Bioverse can now be installed directly from PyPI. To install Bioverse, use the following command:
+
+.. code-block:: bash
+
+    pip install bioverse
+
+Alternatively, Bioverse can be cloned from its GitHub repository:
 
 .. code-block:: bash
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,8 +87,6 @@ Bioverse is compatible with Python 3.7+. It has the following dependencies, all 
 
 .. rubric:: Footnotes
 
-.. [#f1] Bioverse will be added to PyPI in a future update.
-
 Feedback & Development
 **********************
 Bioverse is open source and in active development. We welcome all feedback, bug reports, or feature requests. Feel free to open a pull request if you'd like to contribute! If you think you found a bug, please raise an `issue <https://github.com/danielapai/bioverse/issues>`_.


### PR DESCRIPTION
Added:

Bioverse can now be installed directly from PyPI. To install Bioverse, use the following command:

.. code-block:: bash

    pip install bioverse

Alternatively, Bioverse can be cloned from its GitHub repository:

to README.st and index.rst